### PR TITLE
卒業年日及び学位の追加

### DIFF
--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -100,7 +100,7 @@ export default async function Page() {
             {sortedGraduate.map(([year, people]) => (
               <div key={`graduate-${year}`}>
                 <h3 className="scroll-m-20 pb-2 text-center text-lg font-semibold tracking-tight sm:ml-6 sm:text-left sm:text-xl">
-                  {year}年度卒業生
+                  {Number(year) - 1}年度卒業生
                 </h3>
                 <PeopleList people={people} />
               </div>

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -66,6 +66,10 @@ function PeopleList({ people }: { people: Member[] }) {
 export default async function Page() {
   const { teacher, b3, b4, graduate } = await getMembersJSON();
 
+  const sortedGraduate = Object.entries(graduate).sort(
+    ([a], [b]) => parseInt(b, 10) - parseInt(a, 10)
+  );
+
   return (
     <Container>
       <div className="space-y-16">
@@ -92,7 +96,16 @@ export default async function Page() {
           <h2 className="scroll-m-20 pb-2 text-center text-xl font-semibold tracking-tight sm:text-2xl">
             Alumni / 卒業生
           </h2>
-          <PeopleList people={graduate} />
+          <div className="mt-8 flex flex-col gap-16">
+            {sortedGraduate.map(([year, people]) => (
+              <div>
+                <h3 className="scroll-m-20 pb-2 text-center tracking-tight text-muted-foreground sm:ml-6 sm:text-left sm:text-lg">
+                  {year}年度卒業生
+                </h3>
+                <PeopleList people={people} />
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     </Container>

--- a/src/app/members/page.tsx
+++ b/src/app/members/page.tsx
@@ -98,8 +98,8 @@ export default async function Page() {
           </h2>
           <div className="mt-8 flex flex-col gap-16">
             {sortedGraduate.map(([year, people]) => (
-              <div>
-                <h3 className="scroll-m-20 pb-2 text-center tracking-tight text-muted-foreground sm:ml-6 sm:text-left sm:text-lg">
+              <div key={`graduate-${year}`}>
+                <h3 className="scroll-m-20 pb-2 text-center text-lg font-semibold tracking-tight sm:ml-6 sm:text-left sm:text-xl">
                   {year}年度卒業生
                 </h3>
                 <PeopleList people={people} />

--- a/src/docs/members/index.ts
+++ b/src/docs/members/index.ts
@@ -8,11 +8,15 @@ export type Member = {
   image: string;
 };
 
-const memberKeys = ["teacher", "b4", "b3", "graduate"] as const;
+type GraduateMember = {
+  [key: number]: Member[];
+};
+
+const memberKeys = ["teacher", "b4", "b3"] as const;
 
 export type Members = {
   [key in (typeof memberKeys)[number]]: Member[];
-};
+} & { graduate: GraduateMember };
 
 export const getMembersJSON = async () => {
   const filepath = path.join(

--- a/src/docs/members/members.json
+++ b/src/docs/members/members.json
@@ -170,48 +170,50 @@
     }
   ],
 
-  "graduate": [
-    {
-      "name": "青山瑠壱",
-      "info": "",
-      "href": "https://scrapbox.io/dclab/青山瑠壱",
-      "image": "/graduate/aoyama.webp"
-    },
-    {
-      "name": "神谷彩名",
-      "info": "",
-      "href": "https://scrapbox.io/dclab/神谷彩名",
-      "image": "/graduate/kamiya.webp"
-    },
-    {
-      "name": "竹中隼",
-      "info": "",
-      "href": "https://scrapbox.io/dclab/竹中隼",
-      "image": "/graduate/takenaka.webp"
-    },
-    {
-      "name": "西澤悠貴",
-      "info": "",
-      "href": "https://scrapbox.io/dclab/西澤悠貴",
-      "image": "/graduate/nishizawa.webp"
-    },
-    {
-      "name": "丹羽渚",
-      "info": "",
-      "href": "https://scrapbox.io/dclab/丹羽渚",
-      "image": "/graduate/niwa.webp"
-    },
-    {
-      "name": "古池優大",
-      "info": "",
-      "href": "https://scrapbox.io/dclab/古池優大",
-      "image": "/graduate/koike.webp"
-    },
-    {
-      "name": "八木春樹",
-      "info": "",
-      "href": "https://scrapbox.io/dclab/八木春樹",
-      "image": "/graduate/yagi.webp"
-    }
-  ]
+  "graduate": {
+    "2024": [
+      {
+        "name": "青山瑠壱",
+        "info": "2024卒 / 学士",
+        "href": "https://scrapbox.io/dclab/青山瑠壱",
+        "image": "/graduate/aoyama.webp"
+      },
+      {
+        "name": "神谷彩名",
+        "info": "2024卒 / 学士",
+        "href": "https://scrapbox.io/dclab/神谷彩名",
+        "image": "/graduate/kamiya.webp"
+      },
+      {
+        "name": "竹中隼",
+        "info": "2024卒 / 学士",
+        "href": "https://scrapbox.io/dclab/竹中隼",
+        "image": "/graduate/takenaka.webp"
+      },
+      {
+        "name": "西澤悠貴",
+        "info": "2024卒 / 学士",
+        "href": "https://scrapbox.io/dclab/西澤悠貴",
+        "image": "/graduate/nishizawa.webp"
+      },
+      {
+        "name": "丹羽渚",
+        "info": "2024卒 / 学士",
+        "href": "https://scrapbox.io/dclab/丹羽渚",
+        "image": "/graduate/niwa.webp"
+      },
+      {
+        "name": "古池優大",
+        "info": "2024卒 / 学士",
+        "href": "https://scrapbox.io/dclab/古池優大",
+        "image": "/graduate/koike.webp"
+      },
+      {
+        "name": "八木春樹",
+        "info": "2024卒 / 学士",
+        "href": "https://scrapbox.io/dclab/八木春樹",
+        "image": "/graduate/yagi.webp"
+      }
+    ]
+  }
 }

--- a/src/docs/members/members.json
+++ b/src/docs/members/members.json
@@ -174,43 +174,43 @@
     "2024": [
       {
         "name": "青山瑠壱",
-        "info": "2024卒 / 学士",
+        "info": "2023年度卒 / 学士",
         "href": "https://scrapbox.io/dclab/青山瑠壱",
         "image": "/graduate/aoyama.webp"
       },
       {
         "name": "神谷彩名",
-        "info": "2024卒 / 学士",
+        "info": "2023年度卒 / 学士",
         "href": "https://scrapbox.io/dclab/神谷彩名",
         "image": "/graduate/kamiya.webp"
       },
       {
         "name": "竹中隼",
-        "info": "2024卒 / 学士",
+        "info": "2023年度卒 / 学士",
         "href": "https://scrapbox.io/dclab/竹中隼",
         "image": "/graduate/takenaka.webp"
       },
       {
         "name": "西澤悠貴",
-        "info": "2024卒 / 学士",
+        "info": "2023年度卒 / 学士",
         "href": "https://scrapbox.io/dclab/西澤悠貴",
         "image": "/graduate/nishizawa.webp"
       },
       {
         "name": "丹羽渚",
-        "info": "2024卒 / 学士",
+        "info": "2023年度卒 / 学士",
         "href": "https://scrapbox.io/dclab/丹羽渚",
         "image": "/graduate/niwa.webp"
       },
       {
         "name": "古池優大",
-        "info": "2024卒 / 学士",
+        "info": "2023年度卒 / 学士",
         "href": "https://scrapbox.io/dclab/古池優大",
         "image": "/graduate/koike.webp"
       },
       {
         "name": "八木春樹",
-        "info": "2024卒 / 学士",
+        "info": "2023年度卒 / 学士",
         "href": "https://scrapbox.io/dclab/八木春樹",
         "image": "/graduate/yagi.webp"
       }


### PR DESCRIPTION
# やったこと 
- Memberページの卒業生の卒業年日と学位を追加した。
- jsonのkeyを卒業年日に、infoに学位と卒業年日を追加するようにしたい。
- #30 


# 登録方法
```json
{
  "graduate": {
    "2024": [
      {
        "name": "...",
        "info": "2024卒 / 学士",
        "href": "...",
        "image": "..."
      }
    ],
    "2023": [
      {
        "name": "...",
        "info": "2023卒 / 修士",
        "href": "...",
        "image": "..."
      }
    ]
  }
}

```